### PR TITLE
Fix default compile, add skipPause argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,8 @@ If you want to use a different gamma value than 2.4, you can pass it as an argum
 
 Additionally, you can scale the SDR brightness level by a factor. For example, run `dwm_eotf.exe 2.2 0.5` and set the SDR slider to 0% (= 80 nits) to get 2.2 gamma output with 40 nits peak brightness. Note that some elements of Windows will show artifacts when you do this, so it's not really recommended.
 
+Additionally, if you don't want to have a paused terminal after running the application, append 1 as third parameter. Example: `dwm_eotf.exe 2.4 1.0 1` to run with defaults and close the window automatically.
+
 # Known issues
 * Chromium-based browsers output everything in scRGB if any wide-gamut or HDR content is visible or open in another tab. When this happens, the browser's color management applies the sRGB EOTF to all sRGB content, which this tool cannot do anything against.
+* If executed before Windows Boot has fully concluded, shader patching will usually fail.

--- a/main.c
+++ b/main.c
@@ -244,9 +244,11 @@ typedef LONG (NTAPI *NtSuspendProcess_t)(IN HANDLE ProcessHandle);
 
 typedef LONG (NTAPI *NtResumeProcess_t)(IN HANDLE ProcessHandle);
 
+int skipPause = 0;
+
 int main(int argc, char *argv[]) {
-    if (argc > 3) {
-        printf("Usage: dwm_eotf [gamma [scale factor]]\n");
+    if (argc > 4) {
+        printf("Usage: dwm_eotf [gamma [scale factor [skipPause]]]\n");
         return 1;
     }
     if (argc >= 2) {
@@ -258,7 +260,7 @@ int main(int argc, char *argv[]) {
 
         patchedConstants[0] = gamma;
     }
-    if (argc == 3) {
+    if (argc >= 3) {
         float scale = atof(argv[2]);
         if (scale < 0.01 || scale > 10) {
             printf("Got invalid scale factor %f, exiting\n", scale);
@@ -266,6 +268,9 @@ int main(int argc, char *argv[]) {
         }
 
         patchedConstants[3] = powf(sqrtf(scale), 1 / patchedConstants[0]);
+    }
+    if (argc == 4) {
+        skipPause = atoi(argv[3]);
     }
 
     currentSessionId = WTSGetActiveConsoleSessionId();
@@ -343,12 +348,20 @@ int main(int argc, char *argv[]) {
 
     while (VirtualQueryEx(hProcess, addr + offset, &mbi, sizeof(mbi))) {
         if (mbi.RegionSize > 4096 && mbi.State == MEM_COMMIT && mbi.Protect == PAGE_READONLY) {
-            BYTE buffer[mbi.RegionSize];
+            BYTE *buffer = (BYTE *)malloc(mbi.RegionSize);
+            if (buffer == NULL) {
+                printf("Memory allocation failed.\n");
+                NtResumeProcess(hProcess);
+                CloseHandle(hProcess);
+                system("pause");
+                return 1;
+            }
 
             ReadProcessMemory(hProcess, mbi.BaseAddress, buffer, mbi.RegionSize, &bytesRead);
 
             if (mbi.RegionSize != bytesRead) {
                 printf("tried to read %zu bytes, got %zu\n", mbi.RegionSize, bytesRead);
+                free(buffer);
                 NtResumeProcess(hProcess);
                 CloseHandle(hProcess);
                 return 1;
@@ -358,11 +371,13 @@ int main(int argc, char *argv[]) {
 
             if (!FindAndPatchShaders(buffer, mbi.RegionSize, mbi.BaseAddress, hProcess)) {
                 printf("Error on patching shaders\n");
+                free(buffer);
                 NtResumeProcess(hProcess);
                 CloseHandle(hProcess);
                 return 1;
             }
 
+            free(buffer);
             break;
         }
         offset += mbi.RegionSize;
@@ -390,7 +405,9 @@ int main(int argc, char *argv[]) {
 
     printf("All good?\n");
 
-    system("pause");
+    if (patched == 0 || skipPause == 0) {
+        system("pause");
+    }
 
     return 0;
 }


### PR DESCRIPTION
Make main.c compile with a default Visual Studio Code 2022 installation under Windows 11 - there was an implicit dynamic memory allocation the compiler did not allow, which through the power of vibe coding is now an explicit malloc. I haven't done C in decades but it looks OK to me.

Added an optional fourth parameter "skipPause" because i disliked running this on every boot and having to do 2 actions (click to focus cmd window, hit enter to close it) manually.